### PR TITLE
Adjust post image border color

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,15 @@
+.post-content .body img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  border: 1px solid #ececec;
+}
+
+.post-content .body figure {
+  text-align: center;
+}
+
+.post-content :not(pre) > code {
+  background-color: #343532;
+  color: #ffffff;
+}

--- a/hugo.toml
+++ b/hugo.toml
@@ -11,6 +11,7 @@ pygmentscodefencesguesssyntax = true
 mode = "dark"
 useCDN = false
 subtitle = "Dối lòng sẽ bị quạ bắt diều hâu tha"
+customCSS = ["css/custom.css"]
 
 [[menu.main]]
 name = "Home"


### PR DESCRIPTION
## Summary
- change the post image border color to #ececec for a lighter frame

## Testing
- not run (Hugo CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68d69ef4e0488330a317b0366abfbb0e